### PR TITLE
Add rounding and printing metrics to stdout

### DIFF
--- a/run
+++ b/run
@@ -12,6 +12,7 @@ if [ "$1" == "install" ]; then
   npm install axios || { echo "Failed to install axios"; exit 1; }
   npm install @types/jest || { echo "Failed to install @types/jest"; exit 1; }
   npm install ts-jest || { echo "Failed to install ts-jest"; exit 1; }
+  npm install ndjson || { echo "Failed to install ndjson"; exit 1; }
 
   # Setup Linting (assuming VSCode will handle this, no npm install required)
 

--- a/run_URL_FILE/fetch_url.ts
+++ b/run_URL_FILE/fetch_url.ts
@@ -20,7 +20,7 @@ dotenv.config();
 const rf: number = 5; 
 
 class Package {
-    url: string;
+    url: string = "";
     contributors:Map<string, number> = new Map();
     readmeLength: number = -1;
     rampUp: number = -1;

--- a/run_URL_FILE/fetch_url.ts
+++ b/run_URL_FILE/fetch_url.ts
@@ -5,6 +5,7 @@
 
 import dotenv from 'dotenv'; // For retrieving env variables
 import axios from 'axios'; // Library to conveniantly send HTTP requests to interact with REST API
+import winston from 'winston'; //Logging library
 
 //import * as ndjson from 'ndjson';
 import ndjson from 'ndjson';
@@ -21,7 +22,17 @@ dotenv.config();
 // If that number changes, change this value. 
 const rf: number = 5; 
 
-class Package {
+//Logger initialization
+const logger = winston.createLogger({
+    level: 'info',
+    format: winston.format.simple(),
+    transports: [
+      new winston.transports.File({ filename: 'error.log', level: 'error' }),
+      new winston.transports.File({ filename: 'info.log', level: 'info' }),
+    ],
+  });
+
+export class Package {
     url: string = "";
     contributors:Map<string, number> = new Map();
     readmeLength: number = -1;
@@ -94,13 +105,14 @@ class Package {
     }
   }
 
-function retrieveGithubKey() {
+  function retrieveGithubKey() {
     const githubApiKey = process.env.GITHUB_TOKEN;
     if (!githubApiKey) {
-        console.error("GitHub API key not found in environment variables.");
-        process.exit(1);
+        const error = new Error("GitHub API key not found in environment variables.");
+        logger.error(error);
+        throw error;
     } else {
-        console.log("found github API key");
+        logger.info("found github API key");
         return githubApiKey;
     }
 }
@@ -224,7 +236,7 @@ async function getPackageObject(owner: string, packageName: string, token: strin
 async function cloneRepository(repoUrl: string, packageObj: Package) {
     packageObj.setURL(repoUrl);
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), localDir));
-    console.log('made directory:', dir);
+    logger.info(`made directory: ${dir}`);
     fs.readdirSync(dir);
 
     await git.clone({
@@ -254,7 +266,7 @@ async function cloneRepository(repoUrl: string, packageObj: Package) {
     })
 
     packageObj.setContributors(repoAuthors);
-    console.log(repoAuthors);
+    logger.info(repoAuthors);
 
     // Get readme length
     await readReadmeFile(dir).then ((response) => {
@@ -285,5 +297,10 @@ cloneRepository(exampleUrl.url, packageObj).then ((response) => {
     console.log(packageObj);
 });
 
-console.log("\n\n");
+module.exports = {
+    retrieveGithubKey,
+    getPackageObject,
+    cloneRepository
+};
+
 packageObj.printMetrics();

--- a/run_URL_FILE/fetch_url.ts
+++ b/run_URL_FILE/fetch_url.ts
@@ -6,6 +6,8 @@
 import dotenv from 'dotenv'; // For retrieving env variables
 import axios from 'axios'; // Library to conveniantly send HTTP requests to interact with REST API
 
+//import * as ndjson from 'ndjson';
+import ndjson from 'ndjson';
 import * as git from 'isomorphic-git'; // For cloning repos locally and getting git metadata
 import fs from 'fs'; // Node.js file system module for cloning repos  
 import os from 'os'
@@ -53,17 +55,23 @@ class Package {
     }
 
     printMetrics() {
-        console.log(
-            `\{` +
-            `\"URL\":\"` + this.url + `\", ` +
-            `\"NET_SCORE\":` + `${this.netScore}, ` +              // This metric has a field, but is not implemented
-            `\"RAMP_UP_SCORE\":` + `${this.rampUp}, ` +            // Implemented!
-            `\"CORRECTNESS_SCORE\":` + `${-1}, ` +                 // This metric doesn't seem have a field in this class yet
-            `\"BUS_FACTOR_SCORE\":` + `${this.busFactor}, ` +      // Implemented!
-            `\"RESPONSIVE_MAINTAINER_SCORE\":` + `${-1}, ` +       // This metric deosn't seem have a field in this class yet
-            `\"LICENSE_SCORE\":` + `${Number(this.hasLicense)}` +  // Implemented!
-            `\}\n`
-        );
+        const output = {
+            URL : this.url,                             
+            NET_SCORE: this.netScore,                   // This metric has a field, but is not implemented
+            RAMP_UP_SCORE: this.rampUp,                 // Implemented!
+            CORRECTNESS_SCORE: -1,                      // This metric doesn't seem have a field in this class yet
+            BUS_FACTOR_SCORE: this.busFactor,           // Implemented!
+            RESPONSIVE_MAINTAINER_SCORE: -1,            // This metric doesn't seem have a field in this class yet
+            LICENSE_SCORE: Number(this.hasLicense)      // Implemented!
+        }
+
+        const stringify = ndjson.stringify();
+        stringify.write(output);
+        stringify.end();  // Close the NDJSON serialization
+
+        stringify.on('data', (line: string) => {
+          process.stdout.write(line + '\n');
+        });
     }
   }
 
@@ -276,3 +284,6 @@ cloneRepository(exampleUrl.url, packageObj).then ((response) => {
     packageObj = response;
     console.log(packageObj);
 });
+
+console.log("\n\n");
+packageObj.printMetrics();


### PR DESCRIPTION
I added a method to the Package class that print's the desired output to stdout in the form that was specified on brightspace, for example:

{"URL":"https://github.com/nullivex/nodist", "NET_SCORE":0.9, "RAMP_UP_SCORE":0.5, "CORRECTNESS_SCORE":0.7, "BUS_FACTOR_SCORE":0.3, "RESPONSIVE_MAINTAINER_SCORE":0.4, "LICENSE_SCORE":1}
